### PR TITLE
Fix compile error when CONFIG_CMDLINE is not set

### DIFF
--- a/arch/riscv/kernel/setup.c
+++ b/arch/riscv/kernel/setup.c
@@ -39,7 +39,9 @@
 #include <asm/tlbflush.h>
 #include <asm/thread_info.h>
 
+#ifdef CONFIG_CMDLINE_OVERRIDE
 static char default_command_line[COMMAND_LINE_SIZE] __initdata = CONFIG_CMDLINE;
+#endif
 
 #ifdef CONFIG_EARLY_PRINTK
 static void sbi_console_write(struct console *co, const char *buf,


### PR DESCRIPTION
Fix a yocto build failure when CONFIG_CMDLINE is not set.

> | /scratch/troyb/yocto/build/tmp-glibc/work-shared/freedom-u540/kernel-source/arch/riscv/kernel/setup.c:42:66: error: 'CONFIG_CMDLINE' undeclared here (not in a function); did you mean 'CONFIG_FB_CMDLINE'?
|    42 | static char default_command_line[COMMAND_LINE_SIZE] __initdata = CONFIG_CMDLINE;
|       |                                                                  ^~~~~~~~~~~~~~
|       |                                                                  CONFIG_FB_CMDLINE