### PR TITLE
riscv: asm: fix EIC770X sys/mem port conversion

### DIFF
--- a/arch/riscv/include/asm/pgtable.h
+++ b/arch/riscv/include/asm/pgtable.h
@@ -242,12 +242,12 @@ extern struct pt_alloc_ops pt_ops __initdata;
 
 /* pha conversion between mem port and sys port */
 #define convert_pfn_from_mem_to_sys_port(pfn) \
-	((pfn < DIE0_MEM_PORT_PFN_END)?DIE0_MEM_TO_SYS_PFN_ADDRESS(pfn): \
+	((pfn >= DIE0_MEM_PORT_PFN_START && pfn < DIE0_MEM_PORT_PFN_END)?DIE0_MEM_TO_SYS_PFN_ADDRESS(pfn): \
 	((pfn >= DIE1_MEM_PORT_PFN_START && pfn < DIE1_MEM_PORT_PFN_END)?DIE1_MEM_TO_SYS_PFN_ADDRESS(pfn): \
-	 ((pfn >= INTERLEAVE_MEM_PORT_PFN_START && pfn < INTERLEAVE_MEM_PORT_PFN_END) ? INTERLEAVE_MEM_TO_SYS_PFN_ADDRESS(pfn) : (pfn))))
+	((pfn >= INTERLEAVE_MEM_PORT_PFN_START && pfn < INTERLEAVE_MEM_PORT_PFN_END) ? INTERLEAVE_MEM_TO_SYS_PFN_ADDRESS(pfn) : (pfn))))
 
 #define convert_pfn_from_sys_to_mem_port(pfn) \
-	((pfn < DIE0_SYS_PORT_PFN_END)?DIE0_SYS_TO_MEM_PFN_ADDRESS(pfn): \
+	((pfn >= DIE0_SYS_PORT_PFN_START && pfn < DIE0_SYS_PORT_PFN_END)?DIE0_SYS_TO_MEM_PFN_ADDRESS(pfn): \
 	((pfn >= DIE1_SYS_PORT_PFN_START && pfn < DIE1_SYS_PORT_PFN_END)?DIE1_SYS_TO_MEM_PFN_ADDRESS(pfn): \
 	((pfn >= INTERLEAVE_SYS_PORT_PFN_START && pfn < INTERLEAVE_SYS_PORT_PFN_END) ? INTERLEAVE_SYS_TO_MEM_PFN_ADDRESS(pfn) : (pfn))))
 
@@ -376,12 +376,8 @@ static inline unsigned long pte_pfn(pte_t pte)
 	unsigned long res  = __page_val_to_pfn(pte_val(pte));
 
 #if defined(CONFIG_SOC_SIFIVE_EIC7700)
-	unsigned long pfn_new;
 	if (unlikely(pte_val(pte) & _PAGE_UNCACHE))
-	{
-	    pr_debug("pte_pfn:pfn_sys 0x%lx to pfn_mport 0x%lx\n", (pte_val(pte) >> _PAGE_PFN_SHIFT), pfn_new);
-	    return convert_pfn_from_sys_to_mem_port(pte_val(pte) >> _PAGE_PFN_SHIFT);
-	}
+	    return convert_pfn_from_sys_to_mem_port(res);
 #endif
 
 	if (has_svnapot() && pte_napot(pte))
@@ -398,14 +394,8 @@ static inline pte_t pfn_pte(unsigned long pfn, pgprot_t prot)
 	unsigned long prot_val = pgprot_val(prot);
 
 #if defined(CONFIG_SOC_SIFIVE_EIC7700)
-	unsigned long pfn_new;
-
 	if (unlikely(_PAGE_UNCACHE == (pgprot_val(prot) & _PAGE_UNCACHE)))
-	{
-	    pfn_new = convert_pfn_from_mem_to_sys_port(pfn);
-	    pr_debug("pfn_pte:pfn_mport 0x%lx to pfn_sysport 0x%lx\n", pfn, pfn_new);
-	    return __pte((pfn_new << _PAGE_PFN_SHIFT) | pgprot_val(prot));
-	}
+	    pfn = convert_pfn_from_mem_to_sys_port(pfn);
 #endif
 
 	ALT_THEAD_PMA(prot_val);


### PR DESCRIPTION
This fixes wrong conversion when pfn is not DRAM. Without this fix, accessing MMIO through /dev/mem will result in core hang.